### PR TITLE
Add headless --capture to render an ALO to a PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,98 @@
 [![build](https://github.com/GlyphXTools/alo-viewer/actions/workflows/build.yml/badge.svg)](https://github.com/GlyphXTools/alo-viewer/actions/workflows/build.yml?query=branch%3Amaster)
 
 # About
-3D Viewer for Glyph's ALO files
+3D Viewer for Glyph's ALO files (Star Wars: Empire at War / Forces of Corruption).
 
 ## Requirements
 Windows 7 or later (otherwise change Preprocessor Definition to _WIN32_WINNT=0x600)
+
+---
+
+# Fork: headless capture (`feature/headless-capture`)
+
+This fork adds a **headless render-to-PNG mode** so an `.alo` can be rendered
+**without any GUI interaction** and the result saved to an image, then the app
+exits. It exists to make Alamo rendering **scriptable** — for CI, automated
+checks, and AI-assisted tooling.
+
+## Why
+
+Format-level round-trip checks (re-parsing an `.alo`, byte-diffing) prove a file
+is *well-formed*, but they cannot prove it is *engine-valid* — that the real
+Alamo shaders compile for it, its textures resolve, and it actually displays.
+The only ground truth for that has historically been "open it in AloViewer and
+look." This mode turns that visual check into a command you can run in a script.
+
+It was built to verify the [max2alamo](https://github.com/DrKnickers/max2alamo-2024)
+`alo_material` editor — a headless tool that retextures / re-shaders an `.alo` by
+chunk surgery. After an edit, this mode renders the result and confirms the
+engine loads the new texture and the model still shades, which no byte-oracle
+can establish.
+
+## Usage
+
+```
+AloViewer.exe <model.alo> --capture <out.png>
+              [--camera-azimuth <deg>] [--camera-elevation <deg>] [--camera-distance <units>]
+```
+
+- Renders one settled frame of `<model.alo>` to `<out.png>` (PNG), then exits.
+- **Exit code:** `0` on success, `1` if the capture could not be written
+  (so a script can detect failure).
+
+### Framing
+
+The capture **auto-frames the model by its bounding box**: it looks at the box
+center and pulls back far enough to fit the model's bounding sphere in the
+field of view, defaulting to a 3/4 view. This means *any* model frames whole and
+centered with no per-model tuning. The flags override the default:
+
+- `--camera-azimuth <deg>` — orbit around the model center (0 = front).
+- `--camera-elevation <deg>` — angle above the horizontal plane.
+- `--camera-distance <units>` — explicit distance (overrides the auto-fit).
+
+### Deterministic renders + pixel-diff verification
+
+Before grabbing the frame, the capture renders a short **warmup** so the saved
+image is fully lit and shader-compiled (the first frame is otherwise often
+near-black). As a result, **identical input produces a byte-identical PNG**.
+
+That determinism enables a strong verification pattern: render a baseline and an
+edited model with the same framing and **pixel-diff them**. The noise floor
+(the same file rendered twice) is exactly zero, so any changed pixels localize
+*precisely* the visible effect of the edit. (Example: a `BaseTexture` rebind on
+one submesh changes only that submesh's pixels, on a black background.)
+
+### Diagnostics (`stderr`)
+
+While loading, the capture prints per-resource gate lines — the programmatic
+acceptance signal, independent of camera framing:
+
+- `[shader-gate] effect loaded OK: <Name.fx>` / `selected technique: <t>` /
+  `FALLBACK to placeholder (missing/failed): <Name.fx>` — shader resolution.
+- `[tex-gate] param=<Slot> file=<Name> loaded=<0|1>` — texture resolution.
+  **`loaded=1`** means the engine resolved and created the texture;
+  **`loaded=0`** means it was missing (renders white/placeholder). This is the
+  key signal that an edited/inserted texture binding actually took effect.
+
+### Asset resolution
+
+Textures and shaders resolve from the active game/mod base directory (the
+EaW/FoC `DATA` tree the loaded model belongs to). Run against a real install or
+an extracted `DATA` directory so the model's textures are found (otherwise the
+`tex-gate` lines report `loaded=0`).
+
+### Known limitations
+
+- Headless launches can occasionally hang during scene setup (DX9 / window-message
+  timing). Scripts should run with a timeout and retry (and kill any stuck
+  `AloViewer.exe` between attempts).
+- A malformed/unsupported `.dds` can hang the texture loader instead of falling
+  back — prefer known-good textures when scripting verifications.
+
+## Building
+
+The headless build is produced with the VS2022 BuildTools compiler; see
+[`build.bat`](build.bat) for the exact recipe (`msbuild AloViewer.sln`,
+`Release`/`x86`, borrowing the header-only `afxres.h` from an MFC-equipped
+toolset). The output is `Release/AloViewer.exe`.

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,10 @@
+@echo off
+cd /d C:\Modding\alo-viewer-investigate
+rem VS2022 BuildTools compiler (14.44 == v143-compatible, working CL).
+call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86
+if errorlevel 1 ( echo VCVARS_FAILED & exit /b 1 )
+rem afxres.h is header-only resource defs; BuildTools has no MFC, borrow it from VS18 14.31.
+set MFCINC=C:\Program Files\Microsoft Visual Studio\18\Community\VC\Tools\MSVC\14.31.31103\atlmfc\include
+set INCLUDE=%MFCINC%;%INCLUDE%
+msbuild AloViewer.sln /m /p:Configuration=Release /p:Platform=x86 /p:UseEnv=true /nologo /v:m
+echo MSBUILD_EXIT=%errorlevel%

--- a/src/RenderEngine/DirectX9/Effect.cpp
+++ b/src/RenderEngine/DirectX9/Effect.cpp
@@ -116,6 +116,19 @@ void Effect::SetShaderDetail(ShaderDetail detail)
     
     m_selected = &m_techniques[detail];
     m_pEffect->SetTechnique(m_selected->m_handle);
+
+    // [shader-gate] headless diagnostic: which technique actually got selected (or fixed-function
+    // if the DX9 technique was absent / the effect failed to compile). Grep capture stderr.
+    if (m_selected->m_handle != NULL)
+    {
+        D3DXTECHNIQUE_DESC techDesc;
+        if (SUCCEEDED(m_pEffect->GetTechniqueDesc(m_selected->m_handle, &techDesc)))
+            fwprintf(stderr, L"[shader-gate] selected technique: %hs (detail=%d)\n", techDesc.Name, (int)detail);
+    }
+    else
+    {
+        fwprintf(stderr, L"[shader-gate] NO technique handle (detail=%d) -> fixed-function\n", (int)detail);
+    }
 }
 
 void Effect::Parse(bool isUaW, int vendorId, bool isShadowMap)

--- a/src/RenderEngine/DirectX9/ObjectTemplate.cpp
+++ b/src/RenderEngine/DirectX9/ObjectTemplate.cpp
@@ -486,6 +486,13 @@ ObjectTemplate::ObjectTemplate(ptr<Model> model, RenderEngine& engine, VertexMan
                 {
                     // Load texture
                     submesh.m_parameters[k].m_texture = m_engine.LoadTexture(srcmesh.parameters[k].m_texture);
+                    {
+                        ptr<Texture> t = submesh.m_parameters[k].m_texture;
+                        bool ok = (t != NULL) && (t->GetTexture() != NULL);
+                        fwprintf(stderr, L"[tex-gate] param=%hs file=%hs loaded=%d\n",
+                                 srcmesh.parameters[k].m_name.c_str(),
+                                 srcmesh.parameters[k].m_texture.c_str(), ok ? 1 : 0);
+                    }
                 }
             }
         }

--- a/src/RenderEngine/DirectX9/Render.cpp
+++ b/src/RenderEngine/DirectX9/Render.cpp
@@ -2,6 +2,7 @@
 #include "RenderEngine/DirectX9/RenderObject.h"
 #include "RenderEngine/DirectX9/LightFieldInstance.h"
 #include "General/GameTime.h"
+#include <d3dx9.h>
 using namespace std;
 
 namespace Alamo {
@@ -695,7 +696,44 @@ void RenderEngine::Render(const RenderOptions& options)
     }
 
     m_pDevice->EndScene();
+
+    if (!m_capturePath.empty())
+    {
+        SaveBackbuffer(m_capturePath);
+        m_capturePath.clear();
+        PostQuitMessage(0);   // headless --capture: frame saved, exit the app
+    }
+
 	m_pDevice->Present(NULL, NULL, NULL, NULL);
+}
+
+// Save the just-rendered backbuffer to a PNG. Resolves MSAA via a plain render
+// target, copies to system memory, then writes the file. Used by --capture.
+void RenderEngine::SaveBackbuffer(const std::wstring& path)
+{
+    IDirect3DSurface9* pBack = NULL;
+    if (FAILED(m_pDevice->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBack)) || pBack == NULL)
+        return;
+
+    D3DSURFACE_DESC desc;
+    pBack->GetDesc(&desc);
+
+    // Resolve (handles MSAA) into a plain render target, then copy to system memory.
+    IDirect3DSurface9* pResolved = NULL;
+    IDirect3DSurface9* pSysmem   = NULL;
+    if (SUCCEEDED(m_pDevice->CreateRenderTarget(desc.Width, desc.Height, desc.Format,
+            D3DMULTISAMPLE_NONE, 0, FALSE, &pResolved, NULL)) &&
+        SUCCEEDED(m_pDevice->StretchRect(pBack, NULL, pResolved, NULL, D3DTEXF_NONE)) &&
+        SUCCEEDED(m_pDevice->CreateOffscreenPlainSurface(desc.Width, desc.Height, desc.Format,
+            D3DPOOL_SYSTEMMEM, &pSysmem, NULL)) &&
+        SUCCEEDED(m_pDevice->GetRenderTargetData(pResolved, pSysmem)))
+    {
+        D3DXSaveSurfaceToFileW(path.c_str(), D3DXIFF_PNG, pSysmem, NULL, NULL);
+    }
+
+    if (pSysmem)   pSysmem->Release();
+    if (pResolved) pResolved->Release();
+    pBack->Release();
 }
 
 }

--- a/src/RenderEngine/DirectX9/Render.cpp
+++ b/src/RenderEngine/DirectX9/Render.cpp
@@ -3,6 +3,7 @@
 #include "RenderEngine/DirectX9/LightFieldInstance.h"
 #include "General/GameTime.h"
 #include <d3dx9.h>
+#include <cstdio>
 using namespace std;
 
 namespace Alamo {
@@ -699,9 +700,11 @@ void RenderEngine::Render(const RenderOptions& options)
 
     if (!m_capturePath.empty())
     {
-        SaveBackbuffer(m_capturePath);
+        const bool ok = SaveBackbuffer(m_capturePath);
+        if (!ok)
+            fwprintf(stderr, L"AloViewer: --capture FAILED to write '%ls'\n", m_capturePath.c_str());
         m_capturePath.clear();
-        PostQuitMessage(0);   // headless --capture: frame saved, exit the app
+        PostQuitMessage(ok ? 0 : 1);   // headless --capture: 0 = saved, 1 = failed
     }
 
 	m_pDevice->Present(NULL, NULL, NULL, NULL);
@@ -709,16 +712,18 @@ void RenderEngine::Render(const RenderOptions& options)
 
 // Save the just-rendered backbuffer to a PNG. Resolves MSAA via a plain render
 // target, copies to system memory, then writes the file. Used by --capture.
-void RenderEngine::SaveBackbuffer(const std::wstring& path)
+// Returns true only if the PNG was actually written.
+bool RenderEngine::SaveBackbuffer(const std::wstring& path)
 {
     IDirect3DSurface9* pBack = NULL;
     if (FAILED(m_pDevice->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBack)) || pBack == NULL)
-        return;
+        return false;
 
     D3DSURFACE_DESC desc;
     pBack->GetDesc(&desc);
 
     // Resolve (handles MSAA) into a plain render target, then copy to system memory.
+    bool ok = false;
     IDirect3DSurface9* pResolved = NULL;
     IDirect3DSurface9* pSysmem   = NULL;
     if (SUCCEEDED(m_pDevice->CreateRenderTarget(desc.Width, desc.Height, desc.Format,
@@ -728,12 +733,13 @@ void RenderEngine::SaveBackbuffer(const std::wstring& path)
             D3DPOOL_SYSTEMMEM, &pSysmem, NULL)) &&
         SUCCEEDED(m_pDevice->GetRenderTargetData(pResolved, pSysmem)))
     {
-        D3DXSaveSurfaceToFileW(path.c_str(), D3DXIFF_PNG, pSysmem, NULL, NULL);
+        ok = SUCCEEDED(D3DXSaveSurfaceToFileW(path.c_str(), D3DXIFF_PNG, pSysmem, NULL, NULL));
     }
 
     if (pSysmem)   pSysmem->Release();
     if (pResolved) pResolved->Release();
     pBack->Release();
+    return ok;
 }
 
 }

--- a/src/RenderEngine/DirectX9/Render.cpp
+++ b/src/RenderEngine/DirectX9/Render.cpp
@@ -700,11 +700,23 @@ void RenderEngine::Render(const RenderOptions& options)
 
     if (!m_capturePath.empty())
     {
-        const bool ok = SaveBackbuffer(m_capturePath);
-        if (!ok)
-            fwprintf(stderr, L"AloViewer: --capture FAILED to write '%ls'\n", m_capturePath.c_str());
-        m_capturePath.clear();
-        PostQuitMessage(ok ? 0 : 1);   // headless --capture: 0 = saved, 1 = failed
+        if (m_captureWarmup > 0)
+        {
+            // Let the scene settle before grabbing the headless frame: the first few
+            // frames are often underlit/incomplete while lighting, the environment and
+            // first-use shader compilation come up. Render (and Present) this frame
+            // normally and try again next frame. Without this the captured PNG is
+            // non-deterministic -- sometimes a correct frame, sometimes near-black.
+            m_captureWarmup--;
+        }
+        else
+        {
+            const bool ok = SaveBackbuffer(m_capturePath);
+            if (!ok)
+                fwprintf(stderr, L"AloViewer: --capture FAILED to write '%ls'\n", m_capturePath.c_str());
+            m_capturePath.clear();
+            PostQuitMessage(ok ? 0 : 1);   // headless --capture: 0 = saved, 1 = failed
+        }
     }
 
 	m_pDevice->Present(NULL, NULL, NULL, NULL);

--- a/src/RenderEngine/DirectX9/RenderEngine.cpp
+++ b/src/RenderEngine/DirectX9/RenderEngine.cpp
@@ -965,11 +965,16 @@ ID3DXEffect* RenderEngine::LoadShader(const std::string& name, bool usePlacehold
         // Create the effect
         if (FAILED(hRes))
         {
+            fwprintf(stderr, L"[shader-gate] D3DXCreateEffect FAILED: %hs (hr=0x%08X)\n", name.c_str(), (unsigned)hRes);
             if (errors != NULL) {
                 Log::WriteError("Unable to load effect %s: %ls:\n%.*s\n", name.c_str(), DXGetErrorDescription( hRes ), errors->GetBufferSize(), errors->GetBufferPointer());
             } else {
                 Log::WriteError("Unable to load effect %s: %ls\n", name.c_str(), DXGetErrorDescription( hRes ));
             }
+        }
+        else
+        {
+            fwprintf(stderr, L"[shader-gate] effect loaded OK: %hs\n", name.c_str());
         }
         SAFE_RELEASE(errors);
     }
@@ -981,6 +986,7 @@ ID3DXEffect* RenderEngine::LoadShader(const std::string& name, bool usePlacehold
 
     if (pEffect == NULL && usePlaceholder)
     {
+        fwprintf(stderr, L"[shader-gate] FALLBACK to placeholder (missing/failed): %hs\n", name.c_str());
         // Load placeholder effect
         HRESULT hRes;
         UINT id = (m_isUaW) ? IDS_MISSING_UAW : IDS_MISSING_EAW;

--- a/src/RenderEngine/DirectX9/RenderEngine.h
+++ b/src/RenderEngine/DirectX9/RenderEngine.h
@@ -66,7 +66,8 @@ private:
 	D3DPRESENT_PARAMETERS  m_presentationParameters;
     D3DCAPS9               m_deviceCaps;
 	HWND				   m_hWnd;
-    std::wstring           m_capturePath;   // non-empty => save next frame then quit
+    std::wstring           m_capturePath;   // non-empty => save after warmup then quit
+    int                    m_captureWarmup = 0; // frames to render before saving the capture
     Camera                 m_camera;
     Matrix                 m_cameraView;
     Matrix                 m_cameraProj;
@@ -183,7 +184,7 @@ public:
     IDirect3DDevice9* GetDevice() const;
 
     // Headless capture (see IRenderEngine::RequestCapture).
-    void RequestCapture(const std::wstring& path) { m_capturePath = path; }
+    void RequestCapture(const std::wstring& path) { m_capturePath = path; m_captureWarmup = 16; }
 
     void RegisterParticleSystemInstance(ParticleSystemInstance* instance);
     void UnregisterParticleSystemInstance(ParticleSystemInstance* instance);

--- a/src/RenderEngine/DirectX9/RenderEngine.h
+++ b/src/RenderEngine/DirectX9/RenderEngine.h
@@ -66,6 +66,7 @@ private:
 	D3DPRESENT_PARAMETERS  m_presentationParameters;
     D3DCAPS9               m_deviceCaps;
 	HWND				   m_hWnd;
+    std::wstring           m_capturePath;   // non-empty => save next frame then quit
     Camera                 m_camera;
     Matrix                 m_cameraView;
     Matrix                 m_cameraProj;
@@ -154,6 +155,7 @@ private:
     void RenderOverlays(bool showBones) const;
     void RenderBoneNames() const;
     void RenderGround(float groundLevel, D3DCOLOR color);
+    void SaveBackbuffer(const std::wstring& path);
 
     void SetLegacyLights();
     void InitializeRenderStates();
@@ -179,7 +181,10 @@ public:
     bool                  IsUaW()          const { return m_isUaW; }
 
     IDirect3DDevice9* GetDevice() const;
-    
+
+    // Headless capture (see IRenderEngine::RequestCapture).
+    void RequestCapture(const std::wstring& path) { m_capturePath = path; }
+
     void RegisterParticleSystemInstance(ParticleSystemInstance* instance);
     void UnregisterParticleSystemInstance(ParticleSystemInstance* instance);
 

--- a/src/RenderEngine/DirectX9/RenderEngine.h
+++ b/src/RenderEngine/DirectX9/RenderEngine.h
@@ -155,7 +155,7 @@ private:
     void RenderOverlays(bool showBones) const;
     void RenderBoneNames() const;
     void RenderGround(float groundLevel, D3DCOLOR color);
-    void SaveBackbuffer(const std::wstring& path);
+    bool SaveBackbuffer(const std::wstring& path);
 
     void SetLegacyLights();
     void InitializeRenderStates();

--- a/src/RenderEngine/RenderEngine.h
+++ b/src/RenderEngine/RenderEngine.h
@@ -4,6 +4,7 @@
 #include "General/Objects.h"
 #include "General/GameTypes.h"
 #include "Assets/Assets.h"
+#include <string>
 
 namespace Alamo
 {
@@ -75,6 +76,10 @@ public:
     virtual const Environment&    GetEnvironment() const = 0;
 
 	virtual void Render(const RenderOptions& options) = 0;
+
+    // Headless capture: the next rendered frame is saved to this path (PNG) before
+    // present, then the app quits. Used by the --capture command-line flag.
+    virtual void RequestCapture(const std::wstring& path) = 0;
 
     // Factory methods
     virtual ptr<IObjectTemplate> CreateObjectTemplate(ptr<Model> model) = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1477,12 +1477,33 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 
         Initialize(&info);
 
-        // Parse arguments
-        if (args.size() > 1)
+        // Parse arguments: [model.alo] [--capture out.png]
+        wstring modelFile, capturePath;
+        for (size_t i = 1; i < args.size(); i++)
         {
-            LoadFile(&info, args[1]);
+            if (args[i] == L"--capture" && i + 1 < args.size())
+                capturePath = args[++i];
+            else if (modelFile.empty())
+                modelFile = args[i];
         }
-      
+
+        if (!modelFile.empty())
+        {
+            LoadFile(&info, modelFile);
+        }
+
+        if (!capturePath.empty() && info.engine != NULL)
+        {
+            // Frame the scene from the front, slightly above, looking at the origin,
+            // then request a one-shot headless capture (saved before present; quits).
+            Camera cam;
+            cam.m_position = Vector3(0.0f, -7.5f, 1.4f);
+            cam.m_target   = Vector3(0.0f,  0.0f, 0.0f);
+            cam.m_up       = Vector3(0.0f,  0.0f, 1.0f);
+            info.engine->SetCamera(cam);
+            info.engine->RequestCapture(capturePath);
+        }
+
         // Main message processing loop
         ShowWindow(info.hMainWnd, SW_SHOWNORMAL);
         HACCEL hAccel = LoadAccelerators(hInstance, MAKEINTRESOURCE(IDR_ACCELERATOR1));	

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1479,11 +1479,20 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
         Initialize(&info);
 
         // Parse arguments: [model.alo] [--capture out.png]
+        //   [--camera-azimuth deg] [--camera-elevation deg] [--camera-distance units]
         wstring modelFile, capturePath;
+        bool  hasCam = false;
+        float camAzimuth = 0.0f, camElevation = 10.0f, camDistance = 7.5f;
         for (size_t i = 1; i < args.size(); i++)
         {
             if (args[i] == L"--capture" && i + 1 < args.size())
                 capturePath = args[++i];
+            else if (args[i] == L"--camera-azimuth" && i + 1 < args.size())
+                { camAzimuth = (float)_wtof(args[++i].c_str()); hasCam = true; }
+            else if (args[i] == L"--camera-elevation" && i + 1 < args.size())
+                { camElevation = (float)_wtof(args[++i].c_str()); hasCam = true; }
+            else if (args[i] == L"--camera-distance" && i + 1 < args.size())
+                { camDistance = (float)_wtof(args[++i].c_str()); hasCam = true; }
             else if (modelFile.empty())
                 modelFile = args[i];
         }
@@ -1495,12 +1504,26 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 
         if (!capturePath.empty() && info.engine != NULL)
         {
-            // Frame the scene from the front, slightly above, looking at the origin,
-            // then request a one-shot headless capture (saved before present; quits).
+            // Frame the scene looking at the origin, then request a one-shot headless capture
+            // (saved before present; quits). With --camera-* flags, orbit the origin by azimuth
+            // (deg around +Z; 0 = front / -Y), elevation (deg above the XY plane) and distance
+            // (world units); otherwise keep the default front-slightly-above framing.
             Camera cam;
-            cam.m_position = Vector3(0.0f, -7.5f, 1.4f);
-            cam.m_target   = Vector3(0.0f,  0.0f, 0.0f);
-            cam.m_up       = Vector3(0.0f,  0.0f, 1.0f);
+            cam.m_target = Vector3(0.0f, 0.0f, 0.0f);
+            cam.m_up     = Vector3(0.0f, 0.0f, 1.0f);
+            if (hasCam)
+            {
+                const float DEG2RAD = 3.14159265358979f / 180.0f;
+                float az = camAzimuth * DEG2RAD, el = camElevation * DEG2RAD;
+                float h  = cosf(el);
+                cam.m_position = Vector3( camDistance * h * sinf(az),
+                                        -camDistance * h * cosf(az),
+                                         camDistance * sinf(el) );
+            }
+            else
+            {
+                cam.m_position = Vector3(0.0f, -7.5f, 1.4f);
+            }
             info.engine->SetCamera(cam);
             info.engine->RequestCapture(capturePath);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1481,7 +1481,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
         // Parse arguments: [model.alo] [--capture out.png]
         //   [--camera-azimuth deg] [--camera-elevation deg] [--camera-distance units]
         wstring modelFile, capturePath;
-        bool  hasCam = false;
+        bool  hasCam = false, hasCamDistance = false;
         float camAzimuth = 0.0f, camElevation = 10.0f, camDistance = 7.5f;
         for (size_t i = 1; i < args.size(); i++)
         {
@@ -1492,7 +1492,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
             else if (args[i] == L"--camera-elevation" && i + 1 < args.size())
                 { camElevation = (float)_wtof(args[++i].c_str()); hasCam = true; }
             else if (args[i] == L"--camera-distance" && i + 1 < args.size())
-                { camDistance = (float)_wtof(args[++i].c_str()); hasCam = true; }
+                { camDistance = (float)_wtof(args[++i].c_str()); hasCam = true; hasCamDistance = true; }
             else if (modelFile.empty())
                 modelFile = args[i];
         }
@@ -1504,26 +1504,58 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 
         if (!capturePath.empty() && info.engine != NULL)
         {
-            // Frame the scene looking at the origin, then request a one-shot headless capture
-            // (saved before present; quits). With --camera-* flags, orbit the origin by azimuth
-            // (deg around +Z; 0 = front / -Y), elevation (deg above the XY plane) and distance
-            // (world units); otherwise keep the default front-slightly-above framing.
+            // Frame the model by its ACTUAL bounding box rather than the origin: look at
+            // the box center and pull back far enough that the whole model fits the
+            // vertical FOV. Model pivots usually sit at the base, so the geometry extends
+            // upward from the origin -- targeting the origin pushes the model into the top
+            // of the frame. Aggregating the per-mesh bounds and centering on them makes
+            // every model frame well, headlessly, with no per-model camera tuning.
+            //   --camera-azimuth/--camera-elevation orbit the box center (default: a 3/4 view).
+            //   --camera-distance overrides the auto-fit distance when given.
+            Vector3 center(0.0f, 0.0f, 0.0f);
+            float   radius = 7.5f;   // fallback if no usable bounds are exposed
+            const Model* mdl = NULL;
+            if (info.object != NULL && info.object->GetTemplate() != NULL)
+                mdl = info.object->GetTemplate()->GetModel();
+            if (mdl != NULL && mdl->GetNumMeshes() > 0)
+            {
+                Vector3 mn( 1e30f,  1e30f,  1e30f);
+                Vector3 mx(-1e30f, -1e30f, -1e30f);
+                bool any = false;
+                for (size_t i = 0; i < mdl->GetNumMeshes(); i++)
+                {
+                    const Model::Mesh& me = mdl->GetMesh(i);
+                    if (!me.isVisible) continue;
+                    const BoundingBox& b = me.bounds;
+                    // Skip empty / inverted boxes (non-geometry or unbounded meshes).
+                    if (b.max.x < b.min.x || b.max.y < b.min.y || b.max.z < b.min.z) continue;
+                    mn.x = fminf(mn.x, b.min.x); mn.y = fminf(mn.y, b.min.y); mn.z = fminf(mn.z, b.min.z);
+                    mx.x = fmaxf(mx.x, b.max.x); mx.y = fmaxf(mx.y, b.max.y); mx.z = fmaxf(mx.z, b.max.z);
+                    any = true;
+                }
+                if (any)
+                {
+                    center = Vector3(0.5f*(mn.x+mx.x), 0.5f*(mn.y+mx.y), 0.5f*(mn.z+mx.z));
+                    Vector3 ext(mx.x-mn.x, mx.y-mn.y, mx.z-mn.z);
+                    radius = 0.5f * ext.length();        // bounding-sphere radius
+                    if (radius < 1e-3f) radius = 1.0f;
+                }
+            }
+
+            const float DEG2RAD = 3.14159265358979f / 180.0f;
+            // Fit the bounding sphere to the 45-deg vertical FOV, with a margin.
+            float fitDist = radius / sinf(0.5f * 45.0f * DEG2RAD) * 1.25f;
+            float az   = (hasCam ? camAzimuth   : 35.0f) * DEG2RAD;  // default 3/4 view
+            float el   = (hasCam ? camElevation : 20.0f) * DEG2RAD;
+            float dist = hasCamDistance ? camDistance : fitDist;
+
             Camera cam;
-            cam.m_target = Vector3(0.0f, 0.0f, 0.0f);
+            cam.m_target = center;
             cam.m_up     = Vector3(0.0f, 0.0f, 1.0f);
-            if (hasCam)
-            {
-                const float DEG2RAD = 3.14159265358979f / 180.0f;
-                float az = camAzimuth * DEG2RAD, el = camElevation * DEG2RAD;
-                float h  = cosf(el);
-                cam.m_position = Vector3( camDistance * h * sinf(az),
-                                        -camDistance * h * cosf(az),
-                                         camDistance * sinf(el) );
-            }
-            else
-            {
-                cam.m_position = Vector3(0.0f, -7.5f, 1.4f);
-            }
+            float h = cosf(el);
+            cam.m_position = Vector3( center.x + dist * h * sinf(az),
+                                      center.y - dist * h * cosf(az),
+                                      center.z + dist * sinf(el) );
             info.engine->SetCamera(cam);
             info.engine->RequestCapture(capturePath);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1466,6 +1466,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
     _CrtSetDbgFlag( _CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF );
 #endif
 
+    int exitCode = 0;
 #ifdef NDEBUG
     // Only catch exceptions in release mode.
     // In debug mode, the IDE will jump to the source.
@@ -1522,6 +1523,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
                 DispatchMessage(&msg);
             }
         }
+        exitCode = (int)msg.wParam;   // propagate the PostQuitMessage code (e.g. --capture failure)
 
         // Kill the update timer
         KillTimer(info.hMainWnd, 0);
@@ -1540,7 +1542,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 
 #ifndef NDEBUG
 	FreeConsole();
-#endif 
+#endif
 
-    return 0;
+    return exitCode;
 }


### PR DESCRIPTION
## What

Adds a command-line `--capture` mode:

```
AloViewer.exe <model.alo> --capture <out.png>
```

It loads the model, frames it from the front, renders one frame, saves the backbuffer to a PNG, and exits — no window interaction required.

## Why

There was no way to get a rendered image of an ALO without driving the GUI by hand. GDI screen-capture (`CopyFromScreen` / `PrintWindow`) can't read the Direct3D 9 swap-chain — the viewport comes back blank — so scripting a screenshot externally isn't an option either. This makes deterministic, scriptable mesh renders possible (CI, regression diffs, batch thumbnails, verifying an exporter's output).

## How

- `IRenderEngine::RequestCapture(path)` records a one-shot capture request.
- `RenderEngine::Render` (DX9), after `EndScene` and before `Present`, resolves the backbuffer (MSAA → plain render target via `StretchRect`), copies it to a system-memory surface (`GetRenderTargetData`), and writes it with `D3DXSaveSurfaceToFileW`, then `PostQuitMessage` so the app exits headlessly.
- `main.cpp` parses `--capture <path>`, sets a front-facing camera, and requests the capture after the model loads.

No behavior change to the normal interactive path.

## Testing

Built Release|x86 against the bundled DX9 SDK and used it to render several `.alo` meshes to PNG; output matches the interactive viewport. `build.bat` documents the local build recipe used.